### PR TITLE
Fix example link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bevy_old_tv_shader
 
-An "old TV" effect based on the Bevy [post-processing example](https://github.com/bevyengine/bevy/blob/main/examples/shader/post_processing.rs). 
+An "old TV" effect based on the Bevy [post-processing example](https://github.com/bevyengine/bevy/blob/main/examples/shader/custom_post_processing.rs). 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/0718c9f0-177d-473b-bfe8-13c9482bc197" alt="Movie of the old TV shader effect in action on 'cube' example."/>
 </p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example URL reference for the "old TV" effect in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->